### PR TITLE
fix: create engine/package.json before npm install to prevent global install

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -59,6 +59,11 @@ fi
 
 export PATH="$NODE_DIR/bin:$PATH"
 
+# Ensure a package.json exists so npm installs locally (not globally)
+if [ ! -f "$ENGINE_DIR/package.json" ]; then
+    echo '{"name":"openclaude-portable","version":"1.0.0","private":true}' > "$ENGINE_DIR/package.json"
+fi
+
 if [ ! -d "$ENGINE_DIR/node_modules/@gitlawb/openclaude" ]; then
     echo -e "${YELLOW}[~] Installing OpenClaude Engine...${RESET}"
     cd "$ENGINE_DIR"


### PR DESCRIPTION
## Summary

- Without a `package.json` in `engine/`, `npm install` falls back to a global install inside the portable Node prefix instead of creating a local `node_modules/`
- This causes `OC_BIN` to never be found, falling through to `npx openclaude` which resolves a wrong package (`openclaude@0.0.1`) with no `bin` field
- Fix: write a minimal `package.json` into `engine/` before running `npm install`

Fixes #4

## Test plan

- [ ] Delete `engine/node_modules/` and `engine/package.json` to simulate a fresh clone
- [ ] Run `./start.sh` and verify the engine installs into `engine/node_modules/` (not globally)
- [ ] Confirm `engine/node_modules/@gitlawb/openclaude/bin/openclaude` exists after install
- [ ] Launch AI normally and verify no "could not determine executable to run" error